### PR TITLE
Workaround for CocoaPods activesupport dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: objective-c
 cache: cocoapods
 podfile: Example/Podfile
 before_install:
+- gem install activesupport -v 4.2.5.1
 - gem install cocoapods # Since Travis is not always on latest version
 - pod install --project-directory=Example
 install:


### PR DESCRIPTION
gem is trying to install a beta version of activesupport that is
breaking with the version of ruby that travis is running. Specify the
version of activesupport to install beforehand so gem is satisfied.
